### PR TITLE
Add small.svg test file

### DIFF
--- a/files/images/linked.svg
+++ b/files/images/linked.svg
@@ -1,16 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39 72" style="background:#fff" width="39" height="72">
-<circle r="50" cx="19.5" cy="36" fill="#DDDDDD" />
-<circle r="40" cx="19.5" cy="36" fill="#777777" />
-<circle r="30" cx="19.5" cy="36" fill="#DDDDDD" />
-<circle r="20" cx="19.5" cy="36" fill="#777777" />
-<circle r="10" cx="19.5" cy="36" fill="#DDDDDD" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39 86" style="background:#fff" width="39" height="86">
+<circle r="50" cx="19.5" cy="43" fill="#DDD" />
+<circle r="40" cx="19.5" cy="43" fill="#777" />
+<circle r="30" cx="19.5" cy="43" fill="#DDD" />
+<circle r="20" cx="19.5" cy="43" fill="#777" />
+<circle r="10" cx="19.5" cy="43" fill="#DDD" />
 <image width="19" height="12" href="small.gif" x="10" y="2" />
 <image width="31" height="12" href="small.jpeg" x="4" y="16" />
 <image width="24" height="12" href="small.jpg" x="7.5" y="30" />
 <image width="26" height="12" href="small.png" x="6.5" y="44" />
-<image width="35" height="12" href="small.webp" x="2" y="58" />
-<circle r="10" cx="19.5" cy="36" fill="none" stroke="black" />
-<circle r="20" cx="19.5" cy="36" fill="none" stroke="black" />
-<circle r="30" cx="19.5" cy="36" fill="none" stroke="black" />
-<circle r="40" cx="19.5" cy="36" fill="none" stroke="black" />
+<image width="25" height="12" href="small.svg" x="7" y="58" />
+<image width="35" height="12" href="small.webp" x="2" y="72" />
+<circle r="10" cx="19.5" cy="43" fill="none" stroke="#000" />
+<circle r="20" cx="19.5" cy="43" fill="none" stroke="#000" />
+<circle r="30" cx="19.5" cy="43" fill="none" stroke="#000" />
+<circle r="40" cx="19.5" cy="43" fill="none" stroke="#000" />
 </svg>

--- a/files/images/small.svg
+++ b/files/images/small.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="25" height="12"><path fill="#9f0e0e" d="M0 0h25v12H0z"/><path fill="#fff" d="M20 5h4v5h-1v1h-5v-1h-1V2h1V1h5v1h1v2h-2V3h-2v1h-1v4h1v1h2V7h-2zM13 7h1V1h2v7h-1v1h-1v1h-1v1h-1v-1h-1V9h-1V8H9V1h2v6h1v1h1zM1 8h2v1h3V7H2V6H1V2h1V1h5v1h1v2H6V3H3v2h4v1h1v4H7v1H2v-1H1Z"/></svg>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ files! {
     "images/small.jpeg",
     "images/small.jpg",
     "images/small.png",
+    "images/small.svg",
     "images/small.webp",
     "images/star.pdf",
     "images/tetrahedron.svg",


### PR DESCRIPTION
This adds `small.svg` and includes a link from `linked.svg` to this `small.svg` file.

The extended `linked.svg` file is intended as a test for the fix of the following issue: https://github.com/typst/typst/issues/6858

I've tried to keep the files compact and convenient, and consistent with the other `small.*` files.

This is a follow-up related to the following older PRs:

- #12 
- https://github.com/typst/typst/pull/6794

In a minute, I will open a PR on the main typst repo with the corresponding bug fix, and link back to this one.

I hope it is alright.